### PR TITLE
Add Rei FBX model and improve ECS documentation

### DIFF
--- a/RabOneEngine/include/BaseApp.h
+++ b/RabOneEngine/include/BaseApp.h
@@ -174,6 +174,11 @@ public:
   Texture g_koroTexture; ///< Texture for the Koro model.
   Texture g_planeTexture; ///< Texture for the plane.
   Texture g_shibaTexture; ///< Texture for the Shiba model.
+  Texture g_reiTexture1; ///< Texture 01 for the Rei model.
+  Texture g_reiTexture2; ///< Texture 02 for the Rei model.
+  Texture g_reiTexture3; ///< Texture 03 for the Rei model.
+  Texture g_reiTexture4; ///< Texture 04 for the Rei model.
+  Texture g_reiTexture5; ///< Texture 05 for the Rei model.
 
   // --- Transformation Matrices ---
 
@@ -233,7 +238,11 @@ public:
   EngineUtilities::TSharedPointer<Actor> g_AKoro; ///< Shared pointer to the Koro actor in the scene.
   EngineUtilities::TSharedPointer<Actor> g_APlane; ///< Shared pointer to the plane actor in the scene.
   EngineUtilities::TSharedPointer<Actor> g_AShiba; ///< Shared pointer to the Shiba actor in the scene.
+  EngineUtilities::TSharedPointer<Actor> g_ARei; ///< Shared pointer to therei actor in the scene.
   std::vector<EngineUtilities::TSharedPointer<Actor>> g_actors; ///< Vector of actors in the scene.
+
+  // --- Selected Actor for UI ---
+  EngineUtilities::TSharedPointer<Actor> m_selectedActor; ///< Currently selected actor for transform editing.
 
   XMFLOAT4 g_LightPos; ///< Posición de la luz(2.0f, 4.0f, -2.0f, 1.0f)
 };

--- a/RabOneEngine/include/DeviceContext.h
+++ b/RabOneEngine/include/DeviceContext.h
@@ -9,98 +9,155 @@
  * rendering, resource management, and pipeline state. It is responsible for issuing rendering commands
  * and managing the state of the graphics pipeline.
  */
-class
-  DeviceContext {
+class DeviceContext {
 public:
   /**
-   * @brief Default constructor and destructor.
+   * @brief Default constructor.
    */
   DeviceContext() = default;
+
+  /**
+   * @brief Destructor.
+   */
   ~DeviceContext() = default;
 
   /**
    * @brief Initializes the device context.
+   *
+   * Sets up the device context for use in rendering operations.
    */
-  void
-    init();
+  void init();
 
   /**
    * @brief Updates the device context.
+   *
+   * Updates any internal state or resources associated with the device context.
    */
-  void
-    update();
+  void update();
 
   /**
    * @brief Renders the current frame using the device context.
+   *
+   * Issues rendering commands for the current frame.
    */
-  void
-    render();
+  void render();
 
   /**
    * @brief Destroys the device context and releases resources.
+   *
+   * Cleans up and releases all resources associated with the device context.
    */
-  void
-    destroy();
+  void destroy();
 
   /**
-   * @brief Sets the input layout for the input assembler stage.
+   * @brief Sets the viewports for the rasterizer stage.
    * @param NumViewports Number of viewports to set.
    * @param pViewports Pointer to an array of D3D11_VIEWPORT structures.
    */
-  void
-  RSSetViewports(unsigned int NumViewports,
-                 const D3D11_VIEWPORT* pViewports);
+  void RSSetViewports(unsigned int NumViewports,
+    const D3D11_VIEWPORT* pViewports);
 
+  /**
+   * @brief Sets shader resources for the pixel shader stage.
+   * @param StartSlot The first slot to bind.
+   * @param NumViews Number of shader resource views to bind.
+   * @param ppShaderResourceViews Array of pointers to shader resource views.
+   */
+  void PSSetShaderResources(unsigned int StartSlot,
+    unsigned int NumViews,
+    ID3D11ShaderResourceView* const* ppShaderResourceViews);
 
-  void
-  PSSetShaderResources(unsigned int StartSlot,
-                       unsigned int NumViews,
-                       ID3D11ShaderResourceView* const* ppShaderResourceViews);
+  /**
+   * @brief Sets the input layout for the input assembler stage.
+   * @param pInputLayout Pointer to the input layout object.
+   */
+  void IASetInputLayout(ID3D11InputLayout* pInputLayout);
 
-  void
-  IASetInputLayout(ID3D11InputLayout* pInputLayout);
+  /**
+   * @brief Sets the vertex shader for the pipeline.
+   * @param pVertexShader Pointer to the vertex shader.
+   * @param ppClassInstances Array of class instances for shader interfaces.
+   * @param NumClassInstances Number of class instances.
+   */
+  void VSSetShader(ID3D11VertexShader* pVertexShader,
+    ID3D11ClassInstance* const* ppClassInstances,
+    unsigned int NumClassInstances);
 
-  void
-  VSSetShader(ID3D11VertexShader* pVertexShader,
-      ID3D11ClassInstance* const* ppClassInstances,
-      unsigned int NumClassInstances);
-  void
-  PSSetShader(ID3D11PixelShader* pPixelShader,
-      ID3D11ClassInstance* const* ppClassInstances,
-      unsigned int NumClassInstances);
+  /**
+   * @brief Sets the pixel shader for the pipeline.
+   * @param pPixelShader Pointer to the pixel shader.
+   * @param ppClassInstances Array of class instances for shader interfaces.
+   * @param NumClassInstances Number of class instances.
+   */
+  void PSSetShader(ID3D11PixelShader* pPixelShader,
+    ID3D11ClassInstance* const* ppClassInstances,
+    unsigned int NumClassInstances);
 
-  void
-  UpdateSubresource(ID3D11Resource* pDstResource,
-      unsigned int DstSubresource,
-      const D3D11_BOX* pDstBox,
-      const void* pSrcData,
-      unsigned int SrcRowPitch,
-      unsigned int SrcDepthPitch);
+  /**
+   * @brief Updates a subresource, such as a buffer or texture.
+   * @param pDstResource Pointer to the destination resource.
+   * @param DstSubresource Index of the destination subresource.
+   * @param pDstBox Optional pointer to a box defining the region to update. Can be nullptr for the whole resource.
+   * @param pSrcData Pointer to the source data to copy into the resource.
+   * @param SrcRowPitch Row pitch of the source data.
+   * @param SrcDepthPitch Depth pitch of the source data.
+   */
+  void UpdateSubresource(ID3D11Resource* pDstResource,
+    unsigned int DstSubresource,
+    const D3D11_BOX* pDstBox,
+    const void* pSrcData,
+    unsigned int SrcRowPitch,
+    unsigned int SrcDepthPitch);
 
-  void
-  IASetVertexBuffers(unsigned int StartSlot,
-      unsigned int NumBuffers,
-      ID3D11Buffer* const* ppVertexBuffers,
-      const unsigned int* pStrides,
-      const unsigned int* pOffsets);
+  /**
+   * @brief Sets the vertex buffers for the input assembler stage.
+   * @param StartSlot The first input slot for binding.
+   * @param NumBuffers Number of buffers to bind.
+   * @param ppVertexBuffers Array of pointers to vertex buffers.
+   * @param pStrides Array of stride values for each buffer.
+   * @param pOffsets Array of offset values for each buffer.
+   */
+  void IASetVertexBuffers(unsigned int StartSlot,
+    unsigned int NumBuffers,
+    ID3D11Buffer* const* ppVertexBuffers,
+    const unsigned int* pStrides,
+    const unsigned int* pOffsets);
 
-  void
-  IASetIndexBuffer(ID3D11Buffer* pIndexBuffer,
-      DXGI_FORMAT Format,
-      unsigned int Offset);
+  /**
+   * @brief Sets the index buffer for the input assembler stage.
+   * @param pIndexBuffer Pointer to the index buffer.
+   * @param Format Format of the index data (e.g., DXGI_FORMAT_R16_UINT).
+   * @param Offset Offset (in bytes) from the start of the buffer.
+   */
+  void IASetIndexBuffer(ID3D11Buffer* pIndexBuffer,
+    DXGI_FORMAT Format,
+    unsigned int Offset);
 
-  void
-  PSSetSamplers(unsigned int StartSlot,
-      unsigned int NumSamplers,
-      ID3D11SamplerState* const* ppSamplers);
+  /**
+   * @brief Sets the sampler states for the pixel shader stage.
+   * @param StartSlot The first sampler slot to bind.
+   * @param NumSamplers Number of sampler states to bind.
+   * @param ppSamplers Array of pointers to sampler state objects.
+   */
+  void PSSetSamplers(unsigned int StartSlot,
+    unsigned int NumSamplers,
+    ID3D11SamplerState* const* ppSamplers);
 
-  void
-  RSSetState(ID3D11RasterizerState* pRasterizerState);
+  /**
+   * @brief Sets the rasterizer state.
+   * @param pRasterizerState Pointer to the rasterizer state object.
+   */
+  void RSSetState(ID3D11RasterizerState* pRasterizerState);
 
-  void
-  OMSetBlendState(ID3D11BlendState* pBlendState,
-      const float BlendFactor[4],
-      unsigned int SampleMask);
+  /**
+   * @brief Sets the blend state for the output merger stage.
+   * @param pBlendState Pointer to the blend state object.
+   * @param BlendFactor Array of blend factors.
+   * @param SampleMask Sample mask for multisample anti-aliasing.
+   */
+  void OMSetBlendState(ID3D11BlendState* pBlendState,
+    const float BlendFactor[4],
+    unsigned int SampleMask);
 
   /**
    * @brief Clears the depth-stencil view with the specified flags, depth, and stencil values.
@@ -109,20 +166,18 @@ public:
    * @param Depth Value to clear the depth buffer with.
    * @param Stencil Value to clear the stencil buffer with.
    */
-  void
-  ClearDepthStencilView(ID3D11DepthStencilView* pDepthStencilView,
-                        unsigned int ClearFlags,
-                        float Depth,
-                        UINT8 Stencil);
+  void ClearDepthStencilView(ID3D11DepthStencilView* pDepthStencilView,
+    unsigned int ClearFlags,
+    float Depth,
+    UINT8 Stencil);
 
   /**
    * @brief Clears the render target view with the specified color.
    * @param pRenderTargetView Pointer to the render target view to clear.
    * @param ColorRGBA Array of four floats representing the color to clear with.
    */
-  void
-  ClearRenderTargetView(ID3D11RenderTargetView* pRenderTargetView,
-                        const float ColorRGBA[4]);
+  void ClearRenderTargetView(ID3D11RenderTargetView* pRenderTargetView,
+    const float ColorRGBA[4]);
 
   /**
    * @brief Sets the render targets for the output merger stage.
@@ -130,26 +185,45 @@ public:
    * @param ppRenderTargetViews Array of pointers to render target views.
    * @param pDepthStencilView Pointer to the depth-stencil view.
    */
-  void
-  OMSetRenderTargets(unsigned int NumViews,
-                     ID3D11RenderTargetView* const* ppRenderTargetViews,
-                     ID3D11DepthStencilView* pDepthStencilView);
-  void
-  IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY Topology);
+  void OMSetRenderTargets(unsigned int NumViews,
+    ID3D11RenderTargetView* const* ppRenderTargetViews,
+    ID3D11DepthStencilView* pDepthStencilView);
 
-  void
-  VSSetConstantBuffers(unsigned int StartSlot,
-                       unsigned int NumBuffers,
-                       ID3D11Buffer* const* ppConstantBuffers);
+  /**
+   * @brief Sets the primitive topology for the input assembler stage.
+   * @param Topology The primitive topology (e.g., triangle list, line strip).
+   */
+  void IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY Topology);
 
-  void
-  PSSetConstantBuffers(unsigned int StartSlot,
-                       unsigned int NumBuffers,
-                       ID3D11Buffer* const* ppConstantBuffers);
-  void
-  DrawIndexed(unsigned int IndexCount,
-              unsigned int StartIndexLocation,
-              int BaseVertexLocation);
+  /**
+   * @brief Sets constant buffers for the vertex shader stage.
+   * @param StartSlot The first constant buffer slot to bind.
+   * @param NumBuffers Number of constant buffers to bind.
+   * @param ppConstantBuffers Array of pointers to constant buffer objects.
+   */
+  void VSSetConstantBuffers(unsigned int StartSlot,
+    unsigned int NumBuffers,
+    ID3D11Buffer* const* ppConstantBuffers);
+
+  /**
+   * @brief Sets constant buffers for the pixel shader stage.
+   * @param StartSlot The first constant buffer slot to bind.
+   * @param NumBuffers Number of constant buffers to bind.
+   * @param ppConstantBuffers Array of pointers to constant buffer objects.
+   */
+  void PSSetConstantBuffers(unsigned int StartSlot,
+    unsigned int NumBuffers,
+    ID3D11Buffer* const* ppConstantBuffers);
+
+  /**
+   * @brief Draws indexed, instanced primitives.
+   * @param IndexCount Number of indices to draw.
+   * @param StartIndexLocation Index of the first index to use.
+   * @param BaseVertexLocation Value added to each index before reading a vertex from the vertex buffer.
+   */
+  void DrawIndexed(unsigned int IndexCount,
+    unsigned int StartIndexLocation,
+    int BaseVertexLocation);
 
 public:
   /**

--- a/RabOneEngine/include/ECS/Actor.h
+++ b/RabOneEngine/include/ECS/Actor.h
@@ -13,109 +13,127 @@
 class device;
 class MeshComponent;
 
-class
-  Actor : public Entity {
+/**
+ * @class Actor
+ * @brief Represents an entity in the ECS system that can be rendered and updated.
+ *
+ * The Actor class extends Entity and encapsulates all the resources and logic required
+ * to represent a renderable object in the scene. It manages mesh components, textures,
+ * rendering states, and supports shadow casting.
+ */
+class Actor : public Entity {
 public:
   /**
-   * @brief Constructor por defecto.
+   * @brief Default constructor.
    */
   Actor() = default;
 
   /**
-   * @brief Constructor que inicializa el actor con un dispositivo.
-   * @param device El dispositivo con el cual se inicializa el actor.
+   * @brief Constructs an Actor initialized with a device.
+   * @param device The device used to initialize the actor's resources.
    */
   Actor(Device& device);
 
   /**
-   * @brief Destructor virtual.
+   * @brief Virtual destructor.
    */
-  virtual
-    ~Actor() = default;
-
-  void
-    init() override {}
+  virtual ~Actor() = default;
 
   /**
-   * @brief Actualiza el actor.
-   * @param deltaTime El tiempo transcurrido desde la �ltima actualizaci�n.
-   * @param deviceContext Contexto del dispositivo para operaciones gr�ficas.
+   * @brief Initializes the actor. (No-op override)
    */
-  void
-    update(float deltaTime, DeviceContext& deviceContext) override;
+  void init() override {}
 
   /**
-   * @brief Renderiza el actor.
-   * @param deviceContext Contexto del dispositivo para operaciones gr�ficas.
+   * @brief Updates the actor's state.
+   * @param deltaTime Time elapsed since the last update.
+   * @param deviceContext Device context for graphics operations.
    */
-  void
-    render(DeviceContext& deviceContext) override;
+  void update(float deltaTime, DeviceContext& deviceContext) override;
 
   /**
-   * @brief Destruye el actor y libera los recursos asociados.
+   * @brief Renders the actor.
+   * @param deviceContext Device context for graphics operations.
    */
-  void
-    destroy();
+  void render(DeviceContext& deviceContext) override;
 
   /**
-   * @brief Establece las mallas del actor.
-   * @param device El dispositivo con el cual se inicializan las mallas.
-   * @param meshes Vector de componentes de malla que se van a establecer.
+   * @brief Destroys the actor and releases associated resources.
    */
-  void
-    SetMesh(Device& device, std::vector<MeshComponent> meshes);
+  void destroy();
 
-  std::string
-    getName() {
+  /**
+   * @brief Sets the mesh components for the actor.
+   * @param device The device used to initialize the meshes.
+   * @param meshes Vector of mesh components to assign.
+   */
+  void SetMesh(Device& device, std::vector<MeshComponent> meshes);
+
+  /**
+   * @brief Gets the name of the actor.
+   * @return The actor's name.
+   */
+  std::string getName() {
     return m_name;
   }
 
-  void
-    setName(const std::string& name) {
+  /**
+   * @brief Sets the name of the actor.
+   * @param name The new name for the actor.
+   */
+  void setName(const std::string& name) {
     m_name = name;
   }
 
   /**
-   * @brief Establece las texturas del actor.
-   * @param textures Vector de texturas que se van a establecer.
+   * @brief Sets the textures for the actor.
+   * @param textures Vector of textures to assign.
    */
-  void
-    setTextures(std::vector<Texture> textures) {
+  void setTextures(std::vector<Texture> textures) {
     m_textures = textures;
   }
 
-  void
-    setCastShadow(bool v) {
+  /**
+   * @brief Sets whether the actor can cast shadows.
+   * @param v True if the actor should cast shadows, false otherwise.
+   */
+  void setCastShadow(bool v) {
     castShadow = v;
   }
 
-  bool
-    canCastShadow() const {
+  /**
+   * @brief Checks if the actor can cast shadows.
+   * @return True if the actor casts shadows, false otherwise.
+   */
+  bool canCastShadow() const {
     return castShadow;
   }
 
-  void
-    renderShadow(DeviceContext& deviceContext);
+  /**
+   * @brief Renders the actor's shadow.
+   * @param deviceContext Device context for graphics operations.
+   */
+  void renderShadow(DeviceContext& deviceContext);
 
 private:
-  std::vector<MeshComponent> m_meshes;  ///< Vector de componentes de malla.
-  std::vector<Texture> m_textures;      ///< Vector de texturas.
-  std::vector<Buffer> m_vertexBuffers;  ///< Buffers de v�rtices.
-  std::vector<Buffer> m_indexBuffers;   ///< Buffers de �ndices.
-  BlendState m_blendstate;
-  Rasterizer m_rasterizer;
-  SamplerState m_sampler;
-  CBChangesEveryFrame m_model;          ///< Constante del buffer para cambios en cada frame.
-  Buffer m_modelBuffer;                 ///< Buffer del modelo.
+  std::vector<MeshComponent> m_meshes;  ///< Mesh components associated with the actor.
+  std::vector<Texture> m_textures;      ///< Textures applied to the actor.
+  std::vector<Buffer> m_vertexBuffers;  ///< Vertex buffers for the actor's meshes.
+  std::vector<Buffer> m_indexBuffers;   ///< Index buffers for the actor's meshes.
+  BlendState m_blendstate;              ///< Blend state for rendering.
+  Rasterizer m_rasterizer;              ///< Rasterizer state for rendering.
+  SamplerState m_sampler;               ///< Sampler state for textures.
+  CBChangesEveryFrame m_model;          ///< Per-frame constant buffer data (e.g., world matrix).
+  Buffer m_modelBuffer;                 ///< Constant buffer for per-frame data.
 
   // Shadows
-  ShaderProgram m_shaderShadow;
-  Buffer m_shaderBuffer;
-  BlendState m_shadowBlendState;
-  DepthStencilState m_shadowDepthStencilState;
-  CBChangesEveryFrame m_cbShadow;
+  ShaderProgram m_shaderShadow;         ///< Shader program used for shadow rendering.
+  Buffer m_shaderBuffer;                ///< Buffer for shadow shader data.
+  BlendState m_shadowBlendState;        ///< Blend state for shadow rendering.
+  DepthStencilState m_shadowDepthStencilState; ///< Depth-stencil state for shadow rendering.
+  CBChangesEveryFrame m_cbShadow;       ///< Constant buffer for shadow rendering.
 
-  XMFLOAT4                            m_LightPos;
-  std::string m_name = "Actor";         ///< Nombre del actor.
-  bool castShadow = true;              ///< Indica si el actor proyecta sombras.
+  XMFLOAT4 m_LightPos;                  ///< Light position for shadow calculations.
+  std::string m_name = "Actor";         ///< Name of the actor.
+  bool castShadow = true;               ///< Indicates if the actor casts shadows.
 };

--- a/RabOneEngine/include/ECS/Component.h
+++ b/RabOneEngine/include/ECS/Component.h
@@ -3,51 +3,68 @@
 #include "Prerequisites.h"
 class DeviceContext;
 
-class
-  Component {
+/**
+ * @class Component
+ * @brief Abstract base class for all components in the ECS (Entity-Component-System) architecture.
+ *
+ * The Component class defines the interface and common functionality for all components
+ * that can be attached to entities. Components encapsulate specific behaviors or data,
+ * and are managed by entities. All derived components must implement the lifecycle methods.
+ */
+class Component {
 public:
   /**
-  * @brief Default constructor for the Component class.
-  */
+   * @brief Default constructor for the Component class.
+   */
   Component() = default;
 
   /**
-  * @brief Contructor with component type.
-  * @param type The type of the component.
-  */
+   * @brief Constructor with component type.
+   * @param type The type of the component.
+   */
   Component(const ComponentType type) : m_type(type) {}
 
   /**
-  * @brief Virtual destructor for the Component class.
-  */
-  virtual
-  ~Component() = default;
-
-  virtual void
-  init() = 0; ///< Initialize the component.
+   * @brief Virtual destructor for the Component class.
+   */
+  virtual ~Component() = default;
 
   /**
-  * @brief Virtual method to update the component.
-  * @param deltaTime Time elapsed since the last update.
-  */
-  virtual void
-  update(const float deltaTime) = 0;
+   * @brief Initializes the component.
+   *
+   * This method should be overridden by derived classes to perform any setup required
+   * before the component is used.
+   */
+  virtual void init() = 0;
 
   /**
-  * @brief Virtual method to render the component.
-  * @param deviceContext The device context used for rendering and graphic operations.
-  */
-  virtual void
-  render(DeviceContext& deviceContext) = 0;
+   * @brief Updates the component.
+   * @param deltaTime Time elapsed since the last update (in seconds).
+   *
+   * This method should be overridden by derived classes to update the component's state.
+   */
+  virtual void update(const float deltaTime) = 0;
 
-  virtual void
-  destroy() = 0; ///< Destroy the component and release resources.
   /**
-  * @brief Get the type of the component.
-  * @return The type of the component.
-  */
-  ComponentType
-  getType() const { return m_type; }
+   * @brief Renders the component.
+   * @param deviceContext Reference to the device context for graphics operations.
+   *
+   * This method should be overridden by derived classes to render the component.
+   */
+  virtual void render(DeviceContext& deviceContext) = 0;
+
+  /**
+   * @brief Destroys the component and releases resources.
+   *
+   * This method should be overridden by derived classes to clean up resources.
+   */
+  virtual void destroy() = 0;
+
+  /**
+   * @brief Gets the type of the component.
+   * @return The type of the component.
+   */
+  ComponentType getType() const { return m_type; }
 
 protected:
   ComponentType m_type; ///< Type of the component.

--- a/RabOneEngine/include/ECS/Entity.h
+++ b/RabOneEngine/include/ECS/Entity.h
@@ -4,6 +4,15 @@
 
 class DeviceContext;
 
+/**
+ * @class Entity
+ * @brief Base class for all entities in the ECS (Entity-Component-System) architecture.
+ *
+ * The Entity class provides a common interface for all game or simulation objects that can
+ * contain components. It defines the lifecycle methods (init, update, render, destroy) and
+ * manages a collection of components. Entities can be extended to implement specific logic
+ * and behavior.
+ */
 class Entity {
 public:
   /**
@@ -14,48 +23,64 @@ public:
   /**
    * @brief Virtual destructor for the Entity class.
    */
-  virtual
-    ~Entity() = default;
-  virtual void
-  init() = 0; ///< Initialize the component.
+  virtual ~Entity() = default;
 
   /**
-  * @brief Virtual method to update the component.
-  * @param deltaTime Time elapsed since the last update.
-  */
-  virtual void
-  update(const float deltaTime, DeviceContext& deviceContext) = 0;
+   * @brief Initializes the entity.
+   *
+   * This method should be overridden by derived classes to perform any setup required
+   * before the entity is used.
+   */
+  virtual void init() = 0;
 
   /**
-  * @brief Virtual method to render the component.
-  * @param deviceContext The device context used for rendering and graphic operations.
-  */
-  virtual void
-  render(DeviceContext& deviceContext) = 0;
-
-  virtual void
-  destroy() = 0; ///< Destroy the component and release resources.
+   * @brief Updates the entity.
+   * @param deltaTime Time elapsed since the last update (in seconds).
+   * @param deviceContext Reference to the device context for graphics operations.
+   *
+   * This method should be overridden by derived classes to update the entity's state.
+   */
+  virtual void update(const float deltaTime, DeviceContext& deviceContext) = 0;
 
   /**
-  * @brief Adds a component to the entity.
-  * @tparam T Component type to be added.
-  * @param component Shared pointer to the component to be added.
-  */
-  template <typename T> void
-    addComponent(EngineUtilities::TSharedPointer<T> component) {
+   * @brief Renders the entity.
+   * @param deviceContext Reference to the device context for graphics operations.
+   *
+   * This method should be overridden by derived classes to render the entity.
+   */
+  virtual void render(DeviceContext& deviceContext) = 0;
+
+  /**
+   * @brief Destroys the entity and releases resources.
+   *
+   * This method should be overridden by derived classes to clean up resources.
+   */
+  virtual void destroy() = 0;
+
+  /**
+   * @brief Adds a component to the entity.
+   * @tparam T Type of the component to add (must derive from Component).
+   * @param component Shared pointer to the component to be added.
+   *
+   * The component is stored as a base Component pointer internally.
+   */
+  template <typename T>
+  void addComponent(EngineUtilities::TSharedPointer<T> component) {
     static_assert(std::is_base_of<Component, T>::value,
-                  "T must be derived from Component");
+      "T must be derived from Component");
     m_components.push_back(component.template dynamic_pointer_cast<Component>());
   }
 
   /**
-  * @brief Obtiene un componente del tipo solicitado.
-  * @tparam T Tipo del componente a obtener.
-  * @return Shared pointer al componente solicitado, o nullptr si no existe.
-  */
+   * @brief Gets a component of the specified type.
+   * @tparam T Type of the component to retrieve.
+   * @return Shared pointer to the requested component, or nullptr if not found.
+   *
+   * Iterates through the entity's components and returns the first component
+   * that matches the requested type.
+   */
   template <typename T>
-  EngineUtilities::TSharedPointer<T> 
-  getComponent() {
+  EngineUtilities::TSharedPointer<T> getComponent() {
     for (auto& component : m_components) {
       EngineUtilities::TSharedPointer<T> specificComponent = component.template dynamic_pointer_cast<T>();
       if (specificComponent) {
@@ -64,9 +89,9 @@ public:
     }
     return EngineUtilities::TSharedPointer<T>(); ///< Return nullptr if not found.
   }
-private:
+
 protected:
-  bool m_isActive;
-  int m_id;
+  bool m_isActive; ///< Indicates whether the entity is active.
+  int m_id; ///< Unique identifier for the entity.
   std::vector<EngineUtilities::TSharedPointer<Component>> m_components; ///< Components associated with the entity.
 };

--- a/RabOneEngine/include/ECS/Transform.h
+++ b/RabOneEngine/include/ECS/Transform.h
@@ -3,10 +3,23 @@
 #include "Engine Utilities/Vectors/Vector3.h"
 #include "Component.h"
 
-class
-  Transform : public Component {
+/**
+ * @class Transform
+ * @brief Component that manages position, rotation, scale, and transformation matrix for an entity.
+ *
+ * The Transform component encapsulates the spatial properties of an entity, including its position,
+ * rotation, and scale in 3D space. It also maintains a transformation matrix that can be used for
+ * rendering or physics calculations. This component is fundamental for any object that requires
+ * spatial manipulation in a scene.
+ */
+class Transform : public Component {
 public:
-  // Constructor que inicializa posici�n, rotaci�n y escala por defecto
+  /**
+   * @brief Default constructor.
+   *
+   * Initializes position, rotation, and scale to their default values (usually zero vectors),
+   * and sets the component type to TRANSFORM.
+   */
   Transform() : position(),
     rotation(),
     scale(),
@@ -14,67 +27,98 @@ public:
     Component(ComponentType::TRANSFORM) {
   }
 
-  // M�todos para inicializaci�n, actualizaci�n, renderizado y destrucci�n
-  // Inicializa el objeto Transform
-  void
-    init();
+  /**
+   * @brief Initializes the Transform component.
+   *
+   * This method should be called before using the component to ensure all internal data
+   * is set up correctly.
+   */
+  void init();
 
-  // Actualiza el estado del objeto Transform basado en el tiempo transcurrido
-  // @param deltaTime: Tiempo transcurrido desde la �ltima actualizaci�n
-  void
-    update(float deltaTime) override;
+  /**
+   * @brief Updates the state of the Transform component based on elapsed time.
+   * @param deltaTime Time elapsed since the last update (in seconds).
+   *
+   * This method can be used to animate or otherwise modify the transform over time.
+   */
+  void update(float deltaTime) override;
 
-  // Renderiza el objeto Transform
-  // @param deviceContext: Contexto del dispositivo de renderizado
-  void
-    render(DeviceContext& deviceContext) override {}
+  /**
+   * @brief Renders the Transform component.
+   * @param deviceContext Reference to the device context for graphics operations.
+   *
+   * The default implementation does nothing, as Transform is typically not directly rendered.
+   */
+  void render(DeviceContext& deviceContext) override {}
 
-  // Destruye el objeto Transform y libera recursos
-  void
-    destroy() {}
+  /**
+   * @brief Destroys the Transform component and releases resources.
+   *
+   * The default implementation does nothing, as Transform does not own external resources.
+   */
+  void destroy() {}
 
-  // M�todos de acceso a los datos de posici�n
-  // Retorna la posici�n actual
-  const EngineUtilities::Vector3&
-    getPosition() const { return position; }
+  /**
+   * @brief Gets the current position.
+   * @return Reference to the current position vector.
+   */
+  const EngineUtilities::Vector3& getPosition() const { return position; }
 
-  // Establece una nueva posici�n
-  void
-    setPosition(const EngineUtilities::Vector3& newPos) { position = newPos; }
+  /**
+   * @brief Sets a new position.
+   * @param newPos The new position vector.
+   */
+  void setPosition(const EngineUtilities::Vector3& newPos) { position = newPos; }
 
-  // M�todos de acceso a los datos de rotaci�n
-  // Retorna la rotaci�n actual
-  const EngineUtilities::Vector3&
-    getRotation() const { return rotation; }
+  /**
+   * @brief Gets the current rotation.
+   * @return Reference to the current rotation vector (in degrees or radians, depending on convention).
+   */
+  const EngineUtilities::Vector3& getRotation() const { return rotation; }
 
-  // Establece una nueva rotaci�n
-  void
-    setRotation(const EngineUtilities::Vector3& newRot) { rotation = newRot; }
+  /**
+   * @brief Sets a new rotation.
+   * @param newRot The new rotation vector.
+   */
+  void setRotation(const EngineUtilities::Vector3& newRot) { rotation = newRot; }
 
-  // M�todos de acceso a los datos de escala
-  // Retorna la escala actual
-  const EngineUtilities::Vector3&
-    getScale() const { return scale; }
+  /**
+   * @brief Gets the current scale.
+   * @return Reference to the current scale vector.
+   */
+  const EngineUtilities::Vector3& getScale() const { return scale; }
 
-  // Establece una nueva escala
-  void
-    setScale(const EngineUtilities::Vector3& newScale) { scale = newScale; }
+  /**
+   * @brief Sets a new scale.
+   * @param newScale The new scale vector.
+   */
+  void setScale(const EngineUtilities::Vector3& newScale) { scale = newScale; }
 
-  void
-    setTransform(const EngineUtilities::Vector3& newPos,
-      const EngineUtilities::Vector3& newRot,
-      const EngineUtilities::Vector3& newSca);
+  /**
+   * @brief Sets position, rotation, and scale in a single call.
+   * @param newPos The new position vector.
+   * @param newRot The new rotation vector.
+   * @param newSca The new scale vector.
+   *
+   * This method is useful for updating all transform properties at once.
+   */
+  void setTransform(const EngineUtilities::Vector3& newPos,
+    const EngineUtilities::Vector3& newRot,
+    const EngineUtilities::Vector3& newSca);
 
-  // M�todo para trasladar la posici�n del objeto
-  // @param translation: Vector que representa la cantidad de traslado en cada eje
-  void
-    translate(const EngineUtilities::Vector3& translation);
+  /**
+   * @brief Translates (moves) the object by the given vector.
+   * @param translation Vector representing the amount to move in each axis.
+   *
+   * Adds the translation vector to the current position.
+   */
+  void translate(const EngineUtilities::Vector3& translation);
 
 private:
-  EngineUtilities::Vector3 position;  // Posici�n del objeto
-  EngineUtilities::Vector3 rotation;  // Rotaci�n del objeto
-  EngineUtilities::Vector3 scale;     // Escala del objeto
+  EngineUtilities::Vector3 position;  ///< Position of the object in world space.
+  EngineUtilities::Vector3 rotation;  ///< Rotation of the object (typically in degrees or radians).
+  EngineUtilities::Vector3 scale;     ///< Scale of the object.
 
 public:
-  XMMATRIX matrix;    // Matriz de transformaci�n
+  XMMATRIX matrix;    ///< Transformation matrix representing the combined position, rotation, and scale.
 };

--- a/RabOneEngine/include/ModelLoader.h
+++ b/RabOneEngine/include/ModelLoader.h
@@ -3,40 +3,88 @@
 #include "MeshComponent.h"
 #include "fbxsdk.h"
 
-class
-	ModelLoader {
+/**
+ * @class ModelLoader
+ * @brief Utility class for loading 3D models (OBJ and FBX) and extracting mesh and texture data.
+ *
+ * The ModelLoader class provides methods to load models from OBJ and FBX files, process their nodes,
+ * extract mesh and material information, and store the results in MeshComponent objects. It also
+ * manages FBX SDK resources and collects texture file names referenced by the model.
+ */
+class ModelLoader {
 public:
-	ModelLoader() = default;
-	~ModelLoader() = default;
+  /**
+   * @brief Default constructor.
+   */
+  ModelLoader() = default;
 
-	/* OBJ MODEL LOADER*/
-	MeshComponent
-		LoadOBJModel(const std::string& filePath);
+  /**
+   * @brief Destructor.
+   */
+  ~ModelLoader() = default;
 
-	/* FBX MODEL LOADER*/
-	bool
-		InitializeFBXManager();
+  /**
+   * @brief Loads a model from an OBJ file.
+   * @param filePath Path to the OBJ file.
+   * @return MeshComponent containing the loaded mesh data.
+   *
+   * Parses the OBJ file and extracts vertex, index, and material information.
+   */
+  MeshComponent LoadOBJModel(const std::string& filePath);
 
-	bool
-		LoadFBXModel(const std::string& filePath);
+  /**
+   * @brief Initializes the FBX SDK manager and scene.
+   * @return True if initialization was successful, false otherwise.
+   *
+   * This method must be called before loading FBX models.
+   */
+  bool InitializeFBXManager();
 
-	void
-		ProcessFBXNode(FbxNode* node);
+  /**
+   * @brief Loads a model from an FBX file.
+   * @param filePath Path to the FBX file.
+   * @return True if the model was loaded successfully, false otherwise.
+   *
+   * Loads the FBX file, processes its nodes, and extracts mesh and material data.
+   */
+  bool LoadFBXModel(const std::string& filePath);
 
-	void
-		ProcessFBXMesh(FbxNode* node);
+  /**
+   * @brief Recursively processes an FBX node and its children.
+   * @param node Pointer to the FBX node to process.
+   *
+   * Extracts mesh and material data from the node and its descendants.
+   */
+  void ProcessFBXNode(FbxNode* node);
 
-	void
-		ProcessFBXMaterials(FbxSurfaceMaterial* material);
+  /**
+   * @brief Processes an FBX node containing mesh data.
+   * @param node Pointer to the FBX node with mesh data.
+   *
+   * Extracts vertex and index data from the mesh and stores it in MeshComponent objects.
+   */
+  void ProcessFBXMesh(FbxNode* node);
 
-	std::vector<std::string>
-		GetTextureFileNames() const { return textureFileNames; }
+  /**
+   * @brief Processes an FBX material to extract texture file names.
+   * @param material Pointer to the FBX surface material.
+   *
+   * Collects texture file names referenced by the material for later use.
+   */
+  void ProcessFBXMaterials(FbxSurfaceMaterial* material);
+
+  /**
+   * @brief Gets the list of texture file names referenced by the loaded model.
+   * @return Vector of texture file names.
+   */
+  std::vector<std::string> GetTextureFileNames() const { return textureFileNames; }
 
 private:
-	FbxManager* lSdkManager;
-	FbxScene* lScene;
-	std::vector<std::string> textureFileNames;
+  FbxManager* lSdkManager;                  ///< Pointer to the FBX SDK manager.
+  FbxScene* lScene;                         ///< Pointer to the FBX scene.
+  std::vector<std::string> textureFileNames;///< List of texture file names found in the model.
+
 public:
-	std::string modelName;
-	std::vector<MeshComponent> meshes;
+  std::string modelName;                    ///< Name of the loaded model.
+  std::vector<MeshComponent> meshes;        ///< Mesh components extracted from the model.
 };

--- a/RabOneEngine/include/Rasterizer.h
+++ b/RabOneEngine/include/Rasterizer.h
@@ -4,24 +4,57 @@
 class Device;
 class DeviceContext;
 
-class
-  Rasterizer {
+/**
+ * @class Rasterizer
+ * @brief Encapsulates the Direct3D rasterizer state for controlling how primitives are rendered.
+ *
+ * The Rasterizer class manages the creation, binding, and destruction of a Direct3D rasterizer state object.
+ * This state controls how polygons are rasterized, including culling mode, fill mode, and other rasterization options.
+ * It provides methods for initialization, updating, binding to the pipeline, and cleanup.
+ */
+class Rasterizer {
 public:
+  /**
+   * @brief Default constructor.
+   */
   Rasterizer() = default;
+
+  /**
+   * @brief Destructor.
+   */
   ~Rasterizer() = default;
 
-  HRESULT
-    init(Device device);
+  /**
+   * @brief Initializes the rasterizer state.
+   * @param device The Direct3D device used to create the rasterizer state.
+   * @return HRESULT indicating success or failure of the initialization.
+   *
+   * This method creates and configures the rasterizer state object.
+   */
+  HRESULT init(Device device);
 
-  void
-    update();
+  /**
+   * @brief Updates the rasterizer state.
+   *
+   * This method can be used to update internal state or configuration if needed.
+   */
+  void update();
 
-  void
-    render(DeviceContext& deviceContext);
+  /**
+   * @brief Binds the rasterizer state to the device context for rendering.
+   * @param deviceContext The device context to bind the rasterizer state to.
+   *
+   * This method sets the rasterizer state in the Direct3D pipeline.
+   */
+  void render(DeviceContext& deviceContext);
 
-  void
-    destroy();
+  /**
+   * @brief Releases the rasterizer state and associated resources.
+   *
+   * This method should be called to clean up the rasterizer state when it is no longer needed.
+   */
+  void destroy();
 
 private:
-  ID3D11RasterizerState* m_rasterizerState = nullptr;
+  ID3D11RasterizerState* m_rasterizerState = nullptr; ///< Pointer to the Direct3D rasterizer state object.
 };

--- a/RabOneEngine/include/UserInterface.h
+++ b/RabOneEngine/include/UserInterface.h
@@ -58,10 +58,18 @@ public:
   GUITab(const std::string& tabName);
 
   /**
-   * @brief Place holder method, contains the user interface components to be displayed in the ImGui tab
+   * @brief Shows transform controls for the currently selected actor (if any).
+   * Only the selected actor's transform is shown, as set by SceneGraphGUI.
    */
   void
   TransformGUI(BaseApp& g_bApp);
+
+  /**
+   * @brief Shows a simple scene graph tab listing the main actors.
+   * Clicking an actor selects it for editing in the Transform tab.
+   */
+  void
+  SceneGraphGUI(BaseApp& g_bApp);
 
   /**
    * @brief Allows you to manipulate three float values in the GUI

--- a/RabOneEngine/src/BaseApp.cpp
+++ b/RabOneEngine/src/BaseApp.cpp
@@ -134,18 +134,12 @@ BaseApp::init() {
         MESSAGE("Main", "InitDevice", 
           "Loaded Shiba FBX with " << shibaMeshes.size() << " meshes");
         
-        // Load the texture - corrected filename to match your specification
+        // Load the texture
         hr = g_shibaTexture.init(g_device, "textures/shiba", PNG);
         if (FAILED(hr)) {
           ERROR("Main", "InitDevice",
-            ("Failed to initialize Shiba texture. HRESULT: " + std::to_string(hr)).c_str());
+               ("Failed to initialize Shiba texture. HRESULT: " + std::to_string(hr)).c_str());
           
-          // Try loading a default texture as fallback
-          hr = g_shibaTexture.init(g_device, "Textures/Default", PNG);
-          if (FAILED(hr)) {
-            ERROR("Main", "InitDevice", "Failed to load fallback texture for Shiba");
-            return hr;
-          }
         }
 
         std::vector<Texture> shibaTextures;
@@ -157,8 +151,8 @@ BaseApp::init() {
         // Position the Shiba model next to Koro with better positioning
         g_AShiba->getComponent<Transform>()->setTransform(
           EngineUtilities::Vector3(1.0f, 0.0f, 0.0f), // Position offset from Koro
-          EngineUtilities::Vector3(5.0f, 3.4f, 0.0f),  // No rotation
-          EngineUtilities::Vector3(1.0f, 1.0f, 1.0f) // Smaller scale like Koro
+          EngineUtilities::Vector3(5.0f, 3.4f, 0.0f), 
+          EngineUtilities::Vector3(1.0f, 1.0f, 1.0f)
         );
         g_AShiba->setCastShadow(false);
         g_actors.push_back(g_AShiba);
@@ -175,6 +169,86 @@ BaseApp::init() {
   }
   else {
     ERROR("Main", "InitDevice", "Failed to create Shiba actor.");
+    return E_FAIL;
+  }
+
+  // Set Rei Ayanmi's FBX Model
+  g_ARei = EngineUtilities::TSharedPointer<Actor>(new Actor(g_device));
+
+  if (!g_AShiba.isNull()) {
+    // Load FBX model using ModelLoader
+    if (m_loader.LoadFBXModel("models/Rei.fbx")) {
+      // Get the loaded meshes from the ModelLoader
+      std::vector<MeshComponent> reiMeshes = m_loader.meshes;
+
+      if (!reiMeshes.empty()) {
+        MESSAGE("Main", "InitDevice",
+          "Loaded Rei FBX with " << reiMeshes.size() << " meshes");
+
+      std::vector<Texture> reiTextures;
+
+        // Load the texture 01
+        hr = g_reiTexture1.init(g_device, "textures/Face", PNG);
+        if (FAILED(hr)) {
+          ERROR("Main", "InitDevice",
+            ("Failed to initialize Rei's 01 texture. HRESULT: " + std::to_string(hr)).c_str());
+
+        }
+        reiTextures.push_back(g_reiTexture1);
+        // Load the texture 02
+        hr = g_reiTexture2.init(g_device, "textures/CHR_REI_005_col", PNG);
+        if (FAILED(hr)) {
+          ERROR("Main", "InitDevice",
+            ("Failed to initialize Rei's 02 texture. HRESULT: " + std::to_string(hr)).c_str());
+        }
+        reiTextures.push_back(g_reiTexture2);
+        // Load the texture 03
+        hr = g_reiTexture3.init(g_device, "textures/CHR_REI_005_ilm", PNG);
+        if (FAILED(hr)) {
+          ERROR("Main", "InitDevice",
+            ("Failed to initialize Rei's 03 texture. HRESULT: " + std::to_string(hr)).c_str());
+        }
+        reiTextures.push_back(g_reiTexture3);
+        // Load the texture 04
+        hr = g_reiTexture4.init(g_device, "textures/CHR_REI_005_light", PNG);
+        if (FAILED(hr)) {
+          ERROR("Main", "InitDevice",
+            ("Failed to initialize Rei's 04 texture. HRESULT: " + std::to_string(hr)).c_str());
+        }
+        reiTextures.push_back(g_reiTexture4);
+        // Load the texture 05
+        hr = g_reiTexture5.init(g_device, "textures/CHR_REI_005_shadow", PNG);
+        if (FAILED(hr)) {
+          ERROR("Main", "InitDevice",
+            ("Failed to initialize Rei's 05 texture. HRESULT: " + std::to_string(hr)).c_str());
+        }
+        reiTextures.push_back(g_reiTexture5);
+
+        // Set the meshes and textures for Rei actor
+        g_ARei->SetMesh(g_device, reiMeshes);
+        g_ARei->setTextures(reiTextures);
+
+        // Position the Shiba model next to Koro with better positioning
+        g_ARei->getComponent<Transform>()->setTransform(
+          EngineUtilities::Vector3(-2.0f, 0.0f, 0.0f), // Position offset from Koro
+          EngineUtilities::Vector3(5.0f, -3.4f, 0.0f),  // No rotation
+          EngineUtilities::Vector3(2.0f, 2.0f, 2.0f) 
+        );
+        g_ARei->setCastShadow(false);
+        g_actors.push_back(g_ARei);
+      }
+      else {
+        ERROR("Main", "InitDevice", "No meshes found in FBX model.");
+        return E_FAIL;
+      }
+    }
+    else {
+      ERROR("Main", "InitDevice", "Failed to load FBX model: models/Rei.FBX");
+      return E_FAIL;
+    }
+  }
+  else {
+    ERROR("Main", "InitDevice", "Failed to create Rei's actor.");
     return E_FAIL;
   }
 
@@ -273,9 +347,8 @@ void
 BaseApp::update() {
   // Actualizar la interfaz de usuario
   g_userInterface.update();
-
-  g_userInterface.GUITab("RabOne Main");
   g_userInterface.TransformGUI(*this);
+  g_userInterface.SceneGraphGUI(*this); // Add this line to show the scene graph tab
 
   // Actualizar tiempo (mismo que antes)
   static float t = 0.0f;

--- a/RabOneEngine/src/ModelLoader.cpp
+++ b/RabOneEngine/src/ModelLoader.cpp
@@ -225,7 +225,7 @@ ModelLoader::ProcessFBXMesh(FbxNode* node) {
 				if (u < 0.0f) u += 1.0f;
 				if (v < 0.0f) v += 1.0f;
 
-				vertex.Tex = XMFLOAT2(u, v);
+				vertex.Tex = XMFLOAT2(u, -v);
 			}
 			else {
 				vertex.Tex = XMFLOAT2(0.0f, 0.0f);

--- a/RabOneEngine/src/UserInterface.cpp
+++ b/RabOneEngine/src/UserInterface.cpp
@@ -146,32 +146,54 @@ UserInterface::GUITab(const std::string& tabName) {
 
 void
 UserInterface::TransformGUI(BaseApp& g_bApp) {
-
   ImGui::Begin("Transform");
 
-  // Access the first actor's transform component for demonstration
-  // You may want to modify this to handle multiple actors or a selected actor
-  if (!g_bApp.g_actors.empty() && !g_bApp.g_actors[0].isNull()) {
-    auto transform = g_bApp.g_actors[0]->getComponent<Transform>();
+  // Only show transform controls if an actor is selected
+  if (!g_bApp.m_selectedActor.isNull()) {
+    auto transform = g_bApp.m_selectedActor->getComponent<Transform>();
     if (transform) {
-      // Get current values
+      std::string label = g_bApp.m_selectedActor->getName();
+      if (label.empty()) label = "Selected Actor";
+      ImGui::SeparatorText(label.c_str());
       EngineUtilities::Vector3 position = transform->getPosition();
       EngineUtilities::Vector3 rotation = transform->getRotation();
       EngineUtilities::Vector3 scale = transform->getScale();
-
-      // Create ImGui controls
       ImGui::DragFloat3("Position", &position.x, 0.1f);
       ImGui::DragFloat3("Rotation", &rotation.x, 0.1f);
       ImGui::DragFloat3("Scale", &scale.x, 0.1f);
-
-      // Update the transform component with new values
       transform->setPosition(position);
       transform->setRotation(rotation);
       transform->setScale(scale);
     }
+  } else {
+    ImGui::Text("Select an actor in the Scene Graph to edit its transform.");
   }
-  else {
-    ImGui::Text("No actors available");
+
+  ImGui::End();
+}
+
+void
+UserInterface::SceneGraphGUI(BaseApp& g_bApp) {
+  ImGui::Begin("Scene Graph");
+
+  // Show each actor as selectable
+  if (!g_bApp.g_AKoro.isNull()) {
+    bool selected = (g_bApp.m_selectedActor == g_bApp.g_AKoro);
+    if (ImGui::Selectable("Koro", selected)) {
+      g_bApp.m_selectedActor = g_bApp.g_AKoro;
+    }
+  }
+  if (!g_bApp.g_AShiba.isNull()) {
+    bool selected = (g_bApp.m_selectedActor == g_bApp.g_AShiba);
+    if (ImGui::Selectable("Shiba", selected)) {
+      g_bApp.m_selectedActor = g_bApp.g_AShiba;
+    }
+  }
+  if (!g_bApp.g_ARei.isNull()) {
+    bool selected = (g_bApp.m_selectedActor == g_bApp.g_ARei);
+    if (ImGui::Selectable("Rei", selected)) {
+      g_bApp.m_selectedActor = g_bApp.g_ARei;
+    }
   }
 
   ImGui::End();


### PR DESCRIPTION
Added support for loading and displaying the Rei Ayanami FBX model with multiple textures. Enhanced Doxygen-style documentation for ECS classes (Actor, Component, Entity, Transform), ModelLoader, and Rasterizer. Introduced a scene graph UI tab for actor selection and transform editing, and fixed texture coordinate orientation in FBX loader.